### PR TITLE
chore: update pnpm to 11.13.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "discordworker",
 	"version": "0.0.0",
 	"private": true,
-	"packageManager": "pnpm@11.11.0",
+	"packageManager": "pnpm@11.13.0",
 	"scripts": {
 		"deploy": "wrangler deploy",
 		"start": "wrangler dev",


### PR DESCRIPTION
## Summary

- update `packageManager` from `pnpm@11.11.0` to exact `pnpm@11.13.0`
- keep `package.json` as the single source of truth for the pnpm version
- leave workflows and dependencies unchanged

## Why

The pnpm 11.12.0 update fails in `pnpm/action-setup` v6.0.9 while switching from pnpm 11.7.0, before lint, format, type generation, or tests can run. pnpm 11.13.0 contains the corrected published package structure for this self-update path.

## Validation

- `pnpm install --lockfile-only` (no lockfile diff)
- `pnpm install --frozen-lockfile`
- `pnpm run lint`
- `pnpm run fmt:check`
- `pnpm run cf-typegen` and generated-file diff check
- `pnpm exec tsc --noEmit`
- `pnpm vitest run`
- `aqua exec -- pinact run --check`
- `aqua exec -- zizmor --format github .`
